### PR TITLE
Render basic map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1246,6 +1246,14 @@
         }
       }
     },
+    "@googlemaps/js-api-loader": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.11.1.tgz",
+      "integrity": "sha512-2ug4uBu0onRXTAo7Yxkay5N7pdNIz3XpTElMTLdCtEfQDxikbjeR6GS8atVhblX+ubFBNlXvDzz7VtuXv0vMRQ==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
@@ -1630,6 +1638,11 @@
           }
         }
       }
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
@@ -6678,6 +6691,17 @@
         "ignore": "^5.1.4",
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
+      }
+    },
+    "google-map-react": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/google-map-react/-/google-map-react-2.1.9.tgz",
+      "integrity": "sha512-//Pa0o6sdspU2H0ehVztSDQSnYYeV6TY4Z6ftty34yiCJYLliOzeq17dA9uFkyUFdL+XwbTU6e9mfs+bjBMIzw==",
+      "requires": {
+        "@googlemaps/js-api-loader": "^1.7.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "eventemitter3": "^4.0.4",
+        "prop-types": "^15.7.2"
       }
     },
     "graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "google-map-react": "^2.1.9",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-scripts": "4.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,13 @@
-import "./App.css";
+import './App.css';
 
-import LocationSample from "./LocationSample";
+import LocationSample from './LocationSample';
+import { Map } from './components/Map';
 
 function App() {
   return (
     <div className="App">
       <LocationSample />
+      <Map />
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,10 @@
 import './App.css';
 
-import LocationSample from './LocationSample';
 import { Map } from './components/Map';
 
 function App() {
   return (
     <div className="App">
-      <LocationSample />
       <Map />
     </div>
   );

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -9,7 +9,7 @@ export function Map() {
   const { location, error } = useCurrentLocation();
   const [zoom, setZoom] = useState(11);
   return (
-    <div style={{ height: '100vh', width: '100%' }}>
+    <div style={{ height: '30vh', width: '100%' }}>
       {error && <p>Location Error: {error}</p>}
       {location && (
         <GoogleMapReact

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,18 +1,23 @@
 import { useState } from 'react';
 import GoogleMapReact from 'google-map-react';
 
+import { useCurrentLocation } from '../lib/userLocation';
+
 const API_KEY = 'AIzaSyAs_fPF3j1pcQYUU2s0WMI27zhV7oe8kks';
 
-export function Map({ lat, lng }) {
-  const [center, setCenter] = useState({ lat: 59.95, lng: 30.33 });
+export function Map() {
+  const { location, error } = useCurrentLocation();
   const [zoom, setZoom] = useState(11);
   return (
     <div style={{ height: '100vh', width: '100%' }}>
-      <GoogleMapReact
-        bootstrapURLKeys={{ key: API_KEY }}
-        defaultCenter={center}
-        defaultZoom={zoom}
-      />
+      {error && <p>Location Error: {error}</p>}
+      {location && (
+        <GoogleMapReact
+          bootstrapURLKeys={{ key: API_KEY }}
+          defaultCenter={location}
+          defaultZoom={zoom}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import GoogleMapReact from 'google-map-react';
 
-const API_KEY = 'AIzaSyA_jF-TPUl8qTMZ3BKFTrFOolH9wR7NOz4';
+const API_KEY = 'AIzaSyAs_fPF3j1pcQYUU2s0WMI27zhV7oe8kks';
 
 export function Map({ lat, lng }) {
   const [center, setCenter] = useState({ lat: 59.95, lng: 30.33 });

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+import GoogleMapReact from 'google-map-react';
+
+const API_KEY = 'AIzaSyA_jF-TPUl8qTMZ3BKFTrFOolH9wR7NOz4';
+
+export function Map({ lat, lng }) {
+  const [center, setCenter] = useState({ lat: 59.95, lng: 30.33 });
+  const [zoom, setZoom] = useState(11);
+  return (
+    <div style={{ height: '100vh', width: '100%' }}>
+      <GoogleMapReact
+        bootstrapURLKeys={{ key: API_KEY }}
+        defaultCenter={center}
+        defaultZoom={zoom}
+      />
+    </div>
+  );
+}

--- a/src/lib/userLocation.js
+++ b/src/lib/userLocation.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react';
 
 const useCurrentLocation = (options = {}) => {
   // store error messages in state
@@ -9,7 +9,7 @@ const useCurrentLocation = (options = {}) => {
   // Success handler for geolocation's `getCurrentPosition` method
   const handleSuccess = (position) => {
     const { latitude, longitude } = position.coords;
-    setLocation({ latitude, longitude });
+    setLocation({ lat: latitude, lng: longitude });
   };
 
   // Error handler for geolocation's `getCurrentPosition` method
@@ -22,14 +22,14 @@ const useCurrentLocation = (options = {}) => {
     // Do we want to prompt them to input a location if that's the case?
 
     if (!navigator.geolocation) {
-      setError("Geolocation is not supported");
+      setError('Geolocation is not supported');
     }
 
     // Call the Geolocation API
     navigator.geolocation.getCurrentPosition(
       handleSuccess,
       handleError,
-      options
+      options,
     );
   }, []);
   return { location, error };


### PR DESCRIPTION
## Description

- Adds `react-google-map` as a dependency
- Renders a basic Google Map container in the app
- Centers the map on the user's device location
- Changes the shape output from `useLocation` so that the object is `{lat, lng}` rather than `{latitude, loingitude}`. This makes it easier to plug the location hook data into Google Maps without transforming the object.

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates
![localhost_3000_](https://user-images.githubusercontent.com/13525251/102730490-d0a1a600-42e9-11eb-82a0-19af99c1c7b2.png)

